### PR TITLE
mailto links don't use ://, just :

### DIFF
--- a/views/500.ejs
+++ b/views/500.ejs
@@ -67,7 +67,7 @@
         <% } else { %>
        <p class="error">
           A team of highly trained sea bass is working on this as we speak.<br/>
-          If the problem persists, please <a href="mailto://you@your-domain.com">contact the system administrator</a> and inform them of the time that the error occured, and anything you might have done that may have caused the error.
+          If the problem persists, please <a href="mailto:you@your-domain.com">contact the system administrator</a> and inform them of the time that the error occured, and anything you might have done that may have caused the error.
         </p>
       <% } %>
 


### PR DESCRIPTION
https://tools.ietf.org/html/rfc2368
